### PR TITLE
Install LbireOffice via yum repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,6 @@ Role Variables
 
 * `libreoffice_version` - defines the version of LibreOffice to install
 
-LibreOffice Download URL Note
------------------------------
-
-The default value for the `libreoffice_download_url` variable is:
-
-`http://download.documentfoundation.org/libreoffice/stable/{{ libreoffice_version }}/rpm/x86_64/LibreOffice_{{ libreoffice_version }}_Linux_x86-64_rpm.tar.gz`
-
-If you are affiliated with UCLA, you have the option of overriding this default url value with:
-
-`http://pkgs.library.ucla.edu/libreoffice/LibreOffice_{{ libreoffice_version }}_Linux_x86-64_rpm.tar.gz`
-
-Versions of LibreOffice available via the UCLA URL are:
-
-* `6.0.7`
-
 Dependencies
 ------------
 
@@ -38,4 +23,4 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: uclalib_role_libreoffice, libreoffice_version: '5.4.7' }
+         - { role: uclalib_role_libreoffice, libreoffice_version: '6.0.7' }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,11 @@
 # Example: "5.4.7"
 libreoffice_version: ""
 
-libreoffice_base_url: "http://download.documentfoundation.org/libreoffice/stable"
-
-libreoffice_archive_name: "LibreOffice_{{ libreoffice_version }}_Linux_x86-64_rpm.tar.gz"
-
-libreoffice_download_url: "{{ libreoffice_base_url }}/{{ libreoffice_version }}/rpm/x86_64/{{ libreoffice_archive_name }}"
-
-libreoffice_temp_dir: /tmp
-
 libreoffice_install_path: "/opt/libreoffice{{ libreoffice_version.split('.')[0]}}.{{ libreoffice_version.split('.')[1]}}"
+
+libreoffice_required_packages:
+  - cairo
+  - cups-libs
+  - fontconfig
+  - libSM
+  - libICE

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,38 +1,32 @@
 ---
 
-- name: Download and Unarchive the LibreOffice install files
-  unarchive:
-    src: "{{ libreoffice_download_url }}"
-    dest: "{{ libreoffice_temp_dir }}"
-    remote_src: yes
-    list_files: yes
-  register: libreoffice_file_list
+- name: Ensure libreoffice_version is set
+  assert:
+    that: libreoffice_version|length > 0
+    fail_msg: Please set "libreoffice_version"
+
+- name: Add LibreOffice yum repo
+  yum_repository:
+    name: '{{ libreoffice_repo }}'
+    description: LibreOffice Suite
+    baseurl: http://yum.library.ucla.edu/libre-{{ libreoffice_version }}
+    gpgcheck: false
 
 - name: Generate list of LibreOffice RPMs to be installed
-  find:
-    paths: "{{ libreoffice_temp_dir }}/{{ libreoffice_file_list.files[0] }}/RPMS"
-    patterns: "*.rpm"
-  register: libreoffice_rpms
-  no_log: true
-
-- name: Convert the LibreOffice RPM list into a format to be used by yum
-  set_fact:
-    libreoffice_rpm_list: "{{ libreoffice_rpms.files | map(attribute='path') | list }}"
-  no_log: true
+  shell: # noqa: command-instead-of-module
+    cmd: yum list --disablerepo=\* --enablerepo={{ libreoffice_repo }} --installroot=/nonexistant -q | sed -ne '/Available Packages/{n}; s/ .*//p'
+    warn: false
+  changed_when: false
+  check_mode: false
+  register: libreoffice_rpm_list
 
 - name: Install LibreOffice RPMS
   yum:
-    name: "{{ item }}"
+    name: "{{ libreoffice_rpm_list.stdout_lines + libreoffice_required_packages }}"
     state: present
-  with_items: "{{ libreoffice_rpm_list }}"
 
 - name: Create LibreOffice symblink in user path
   file:
-    src: "{{ libreoffice_install_path}}/program/soffice"
+    src: "{{ libreoffice_install_path }}/program/soffice"
     path: "/usr/local/bin/soffice"
     state: link
-
-- name: Clean-up LibreOffice RPM files
-  file:
-    path: "{{ libreoffice_temp_dir }}/{{ libreoffice_file_list.files[0] }}"
-    state: absent

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+libreoffice_repo: libreoffice


### PR DESCRIPTION
The previous incarnation grabbed the RPMs from a tarball, and called
yum to install them. When re-running the role, yum would declare
there is nothing to do and error. While this sounds like a bug in
yum, it caused the role to fail.

Using a repository, and attempting to reinstall via yum results in
yum declaring there is nothing to do and exiting with success.

The previous incarnation installed _all_ the RPMs, and this one does as
well. It uses a yum trick to list all the RPMs in a given repository
to blanket install all of them.